### PR TITLE
Simplify ChooseTopUpMethod

### DIFF
--- a/universal-login-react/src/core/models/TopUpComponentType.ts
+++ b/universal-login-react/src/core/models/TopUpComponentType.ts
@@ -3,5 +3,7 @@ export enum TopUpComponentType {
   'safello',
   'ramp',
   'wyre',
-  'waitForRamp'
+  'waitForRamp',
+  'fiat',
+  'crypto',
 }

--- a/universal-login-react/src/core/models/TopUpComponentType.ts
+++ b/universal-login-react/src/core/models/TopUpComponentType.ts
@@ -3,7 +3,5 @@ export enum TopUpComponentType {
   'safello',
   'ramp',
   'wyre',
-  'waitForRamp',
-  'fiat',
-  'crypto',
+  'waitForRamp'
 }

--- a/universal-login-react/src/ui/TopUp/ChooseTopUpMethod.tsx
+++ b/universal-login-react/src/ui/TopUp/ChooseTopUpMethod.tsx
@@ -9,18 +9,18 @@ import {ChooseTopUpMethodHeader} from './ChooseTopUpMethodHeader';
 import {ModalProgressBar} from '../commons/ModalProgressBar';
 import {classForComponent} from '../utils/classFor';
 import {CompanyLogo} from '../commons/CompanyLogo';
+import {TopUpComponentType} from '../../core/models/TopUpComponentType';
 
 export interface ChooseTopUpMethodProps {
   walletService: WalletService;
   onPayClick: (topUpProvider: TopUpProvider, amount: string) => void;
   logoColor?: LogoColor;
+  setTopUpMethod: (any: any) => void;
+  topUpMethod: TopUpMethod;
+  setModal?: (any: any) => void;
 }
 
-export const ChooseTopUpMethod = ({walletService, onPayClick, logoColor}: ChooseTopUpMethodProps) => {
-  const [topUpMethod, setTopUpMethod] = useState<TopUpMethod>(undefined);
-  const [amount, setAmount] = useState('');
-  const [paymentMethod, setPaymentMethod] = useState<TopUpProvider | undefined>(undefined);
-
+export const ChooseTopUpMethod = ({walletService, topUpMethod, setTopUpMethod, setModal}: ChooseTopUpMethodProps) => {
   return (
     <ChooseTopUpMethodWrapper topUpMethod={topUpMethod}>
       <CompanyLogo />
@@ -31,18 +31,6 @@ export const ChooseTopUpMethod = ({walletService, onPayClick, logoColor}: Choose
         topUpMethod={topUpMethod}
         setTopUpMethod={setTopUpMethod}
       />
-      {topUpMethod === 'fiat' && <TopUpWithFiat
-        walletService={walletService}
-        amount={amount}
-        onAmountChange={setAmount}
-        paymentMethod={paymentMethod}
-        onPaymentMethodChange={setPaymentMethod}
-        logoColor={logoColor}
-        onPayClick={onPayClick}
-      />}
-      {topUpMethod === 'crypto' && <TopUpWithCrypto
-        walletService={walletService}
-      />}
     </ChooseTopUpMethodWrapper>
   );
 };

--- a/universal-login-react/src/ui/TopUp/ChooseTopUpMethod.tsx
+++ b/universal-login-react/src/ui/TopUp/ChooseTopUpMethod.tsx
@@ -1,26 +1,17 @@
-import React, {useState} from 'react';
-import {WalletService} from '@unilogin/sdk';
-import {LogoColor, TopUpWithFiat} from './Fiat';
-import {TopUpWithCrypto} from './TopUpWithCrypto';
-import {TopUpProvider} from '../../core/models/TopUpProvider';
+import React from 'react';
 import {TopUpMethod} from '../../core/models/TopUpMethod';
 import {ChooseTopUpMethodWrapper} from './ChooseTopUpMethodWrapper';
 import {ChooseTopUpMethodHeader} from './ChooseTopUpMethodHeader';
 import {ModalProgressBar} from '../commons/ModalProgressBar';
 import {classForComponent} from '../utils/classFor';
 import {CompanyLogo} from '../commons/CompanyLogo';
-import {TopUpComponentType} from '../../core/models/TopUpComponentType';
 
 export interface ChooseTopUpMethodProps {
-  walletService: WalletService;
-  onPayClick: (topUpProvider: TopUpProvider, amount: string) => void;
-  logoColor?: LogoColor;
   setTopUpMethod: (any: any) => void;
   topUpMethod: TopUpMethod;
-  setModal?: (any: any) => void;
 }
 
-export const ChooseTopUpMethod = ({walletService, topUpMethod, setTopUpMethod, setModal}: ChooseTopUpMethodProps) => {
+export const ChooseTopUpMethod = ({topUpMethod, setTopUpMethod}: ChooseTopUpMethodProps) => {
   return (
     <ChooseTopUpMethodWrapper topUpMethod={topUpMethod}>
       <CompanyLogo />

--- a/universal-login-react/src/ui/TopUp/TopUp.tsx
+++ b/universal-login-react/src/ui/TopUp/TopUp.tsx
@@ -34,12 +34,10 @@ export interface TopUpProps {
 export const TopUp = ({walletService, startModal, modalClassName, hideModal, isModal, logoColor}: TopUpProps) => {
   const [modal, setModal] = useState<TopUpComponentType>(startModal || TopUpComponentType.choose);
   const [amount, setAmount] = useState('');
-  // const [amount, setAmount] = useState('');
   const [paymentMethod, setPaymentMethod] = useState<TopUpProvider | undefined>(undefined);
   const relayerConfig = walletService.sdk.getRelayerConfig();
   const contractAddress = walletService.getContractAddress();
   const [topUpMethod, setTopUpMethod] = useState<TopUpMethod>(undefined);
-
 
   const onPayClick = (provider: TopUpProvider, amount: string) => {
     setTopUpMethod(undefined);
@@ -49,10 +47,6 @@ export const TopUp = ({walletService, startModal, modalClassName, hideModal, isM
 
   const getTopUpMethodChooser = () => (
     <ChooseTopUpMethod
-      walletService={walletService}
-      onPayClick={onPayClick}
-      setModal={setModal}
-      logoColor={logoColor}
       topUpMethod={topUpMethod}
       setTopUpMethod={setTopUpMethod}
     />
@@ -64,14 +58,7 @@ export const TopUp = ({walletService, startModal, modalClassName, hideModal, isM
     return (
       <>
         <ModalWrapper message={walletService.sdk.getNotice()} modalClassName="top-up-modal" hideModal={hideModal}>
-          <ChooseTopUpMethod
-            walletService={walletService}
-            onPayClick={onPayClick}
-            setModal={setModal}
-            logoColor={logoColor}
-            topUpMethod={topUpMethod}
-            setTopUpMethod={setTopUpMethod}
-          />
+          {getTopUpMethodChooser()}
           <ThemedComponent name="top-up">
             <div className='unilogin-component-top-up'>
               <TopUpWithFiat
@@ -90,14 +77,7 @@ export const TopUp = ({walletService, startModal, modalClassName, hideModal, isM
   } else if (topUpMethod === 'crypto') {
     return (<>
       <ModalWrapper message={walletService.sdk.getNotice()} modalClassName="top-up-modal" hideModal={hideModal}>
-        <ChooseTopUpMethod
-          walletService={walletService}
-          onPayClick={onPayClick}
-          setModal={setModal}
-          logoColor={logoColor}
-          topUpMethod={topUpMethod}
-          setTopUpMethod={setTopUpMethod}
-        />
+        {getTopUpMethodChooser()}
         <ThemedComponent name="top-up">
           <div className='unilogin-component-top-up'>
             <TopUpWithCrypto
@@ -151,9 +131,6 @@ export const TopUp = ({walletService, startModal, modalClassName, hideModal, isM
       />
     );
   } else {
-    console.log('?????', modal)
-    console.log('TopUpComponentType.fiat ', TopUpComponentType.fiat)
-    console.log('eq?', TopUpComponentType.choose)
     throw new Error(`Unsupported type: ${modal}`);
   }
 };

--- a/universal-login-react/src/ui/TopUp/TopUp.tsx
+++ b/universal-login-react/src/ui/TopUp/TopUp.tsx
@@ -52,12 +52,12 @@ export const TopUp = ({walletService, startModal, modalClassName, hideModal, isM
     />
   );
 
-  if (!relayerConfig) {
-    return <Spinner />;
-  } else if (topUpMethod === 'fiat') {
-    return (
-      <>
-        <ModalWrapper message={walletService.sdk.getNotice()} modalClassName="top-up-modal" hideModal={hideModal}>
+  const renderTopUpContent = () => {
+    if (!relayerConfig) {
+      return <Spinner />;
+    } else if (topUpMethod === 'fiat') {
+      return (
+        <>
           {getTopUpMethodChooser()}
           <ThemedComponent name="top-up">
             <div className='unilogin-component-top-up'>
@@ -72,11 +72,9 @@ export const TopUp = ({walletService, startModal, modalClassName, hideModal, isM
               />
             </div>
           </ThemedComponent>
-        </ModalWrapper>
-      </>);
-  } else if (topUpMethod === 'crypto') {
-    return (<>
-      <ModalWrapper message={walletService.sdk.getNotice()} modalClassName="top-up-modal" hideModal={hideModal}>
+        </>);
+    } else if (topUpMethod === 'crypto') {
+      return (<>
         {getTopUpMethodChooser()}
         <ThemedComponent name="top-up">
           <div className='unilogin-component-top-up'>
@@ -85,52 +83,54 @@ export const TopUp = ({walletService, startModal, modalClassName, hideModal, isM
             />
           </div>
         </ThemedComponent>
-      </ModalWrapper>
-    </>);
-  } else if (modal === TopUpComponentType.choose) {
-    if (isModal) {
-      return <ModalWrapper message={walletService.sdk.getNotice()} modalClassName="top-up-modal" hideModal={hideModal}>{getTopUpMethodChooser()}</ModalWrapper>;
-    }
-    return getTopUpMethodChooser();
-  } else if (modal === TopUpComponentType.safello) {
-    return (
-      <ModalWrapper modalClassName={modalClassName} hideModal={() => setModal(TopUpComponentType.choose)}>
+      </>);
+    } else if (modal === TopUpComponentType.choose) {
+      return getTopUpMethodChooser();
+    } else if (modal === TopUpComponentType.safello) {
+      return (
         <Safello
           localizationConfig={{} as any}
           safelloConfig={relayerConfig.onRampProviders.safello}
           contractAddress={contractAddress}
           crypto="eth"
         />
-      </ModalWrapper>
-    );
-  } else if (modal === TopUpComponentType.ramp) {
-    return (
-      <Ramp
-        address={contractAddress}
-        amount={stringToEther(amount)}
-        currency={'ETH'}
-        config={relayerConfig.onRampProviders.ramp}
-        onSuccess={() => setModal(TopUpComponentType.waitForRamp)}
-        onCancel={() => setModal(TopUpComponentType.choose)}
-      />
-    );
-  } else if (modal === TopUpComponentType.wyre) {
-    return (
-      <Wyre
-        address={contractAddress}
-        currency={'ETH'}
-        config={relayerConfig.onRampProviders.wyre}
-      />
-    );
-  } else if (modal === TopUpComponentType.waitForRamp) {
-    return (
-      <WaitingForOnRampProvider
-        className={modalClassName}
-        onRampProviderName={'ramp'}
-        logoColor={logoColor}
-      />
-    );
-  } else {
-    throw new Error(`Unsupported type: ${modal}`);
+      );
+    } else if (modal === TopUpComponentType.ramp) {
+      return (
+        <Ramp
+          address={contractAddress}
+          amount={stringToEther(amount)}
+          currency={'ETH'}
+          config={relayerConfig.onRampProviders.ramp}
+          onSuccess={() => setModal(TopUpComponentType.waitForRamp)}
+          onCancel={() => setModal(TopUpComponentType.choose)}
+        />
+      );
+    } else if (modal === TopUpComponentType.wyre) {
+      return (
+        <Wyre
+          address={contractAddress}
+          currency={'ETH'}
+          config={relayerConfig.onRampProviders.wyre}
+        />
+      );
+    } else if (modal === TopUpComponentType.waitForRamp) {
+      return (
+        <WaitingForOnRampProvider
+          className={modalClassName}
+          onRampProviderName={'ramp'}
+          logoColor={logoColor}
+        />
+      );
+    } else {
+      throw new Error(`Unsupported type: ${modal}`);
+    }
+  };
+
+  if (isModal) {
+    return <ModalWrapper message={walletService.sdk.getNotice()} modalClassName="top-up-modal" hideModal={hideModal}>
+      {renderTopUpContent()}
+    </ModalWrapper>;
   }
+  return renderTopUpContent();
 };

--- a/universal-login-react/src/ui/TopUp/TopUp.tsx
+++ b/universal-login-react/src/ui/TopUp/TopUp.tsx
@@ -60,28 +60,24 @@ export const TopUp = ({walletService, startModal, modalClassName, hideModal, isM
         <>
           {getTopUpMethodChooser()}
           <ThemedComponent name="top-up">
-            <div className='unilogin-component-top-up'>
-              <TopUpWithFiat
-                walletService={walletService}
-                amount={amount}
-                onAmountChange={setAmount}
-                paymentMethod={paymentMethod}
-                onPaymentMethodChange={setPaymentMethod}
-                logoColor={logoColor}
-                onPayClick={onPayClick}
-              />
-            </div>
+            <TopUpWithFiat
+              walletService={walletService}
+              amount={amount}
+              onAmountChange={setAmount}
+              paymentMethod={paymentMethod}
+              onPaymentMethodChange={setPaymentMethod}
+              logoColor={logoColor}
+              onPayClick={onPayClick}
+            />
           </ThemedComponent>
         </>);
     } else if (topUpMethod === 'crypto') {
       return (<>
         {getTopUpMethodChooser()}
         <ThemedComponent name="top-up">
-          <div className='unilogin-component-top-up'>
-            <TopUpWithCrypto
-              walletService={walletService}
-            />
-          </div>
+          <TopUpWithCrypto
+            walletService={walletService}
+          />
         </ThemedComponent>
       </>);
     } else if (modal === TopUpComponentType.choose) {

--- a/universal-login-react/src/ui/TopUp/TopUpWithCrypto.tsx
+++ b/universal-login-react/src/ui/TopUp/TopUpWithCrypto.tsx
@@ -33,41 +33,43 @@ export const TopUpWithCrypto = ({walletService}: TopUpWithCryptoProps) => {
   }, []);
 
   return (
-    <div className={classForComponent('top-up-body')}>
-      <div className={classForComponent('top-up-body-inner')}>
-        <div className={`crypto ${cryptoClass}`}>
-          <Label htmlFor="input-address">Send to</Label>
-          <div className={classForComponent('top-up-row')}>
-            <InputCopy
-              id="contract-address"
-              defaultValue={contractAddress}
-              readOnly
-            />
-            <button
-              onClick={() => setIsQrCodeVisible(!isQrCodeVisible)}
-              className={classForComponent('top-up-qr-toggler')}
-            />
-          </div>
-
-          {(isQrCodeVisible || theme === 'default' || theme === 'jarvis') &&
-            <div className={classForComponent('qr-code-wrapper')}>
-              <QRCode
-                level="M"
-                bgColor="#ffffff"
-                fgColor="#120839"
-                width={128}
-                height={128}
-                value={contractAddress}
+    <div className={classForComponent('top-up-body-crypto')}>
+      <div className={classForComponent('top-up-body')}>
+        <div className={classForComponent('top-up-body-inner')}>
+          <div className={`crypto ${cryptoClass}`}>
+            <Label htmlFor="input-address">Send to</Label>
+            <div className={classForComponent('top-up-row')}>
+              <InputCopy
+                id="contract-address"
+                defaultValue={contractAddress}
+                readOnly
+              />
+              <button
+                onClick={() => setIsQrCodeVisible(!isQrCodeVisible)}
+                className={classForComponent('top-up-qr-toggler')}
               />
             </div>
-          }
-          {walletService.isKind('Future')
-            ? <DeploymentWithCryptoInfo minimalAmount={walletService.getRequiredDeploymentBalance()}/>
-            : <TopUpCryptoInfo/>
-          }
-          {walletService.isKind('Future') &&
-            <IncomingTransactionsView futureWallet={walletService.getFutureWallet()}/>
-          }
+
+            {(isQrCodeVisible || theme === 'default' || theme === 'jarvis') &&
+              <div className={classForComponent('qr-code-wrapper')}>
+                <QRCode
+                  level="M"
+                  bgColor="#ffffff"
+                  fgColor="#120839"
+                  width={128}
+                  height={128}
+                  value={contractAddress}
+                />
+              </div>
+            }
+            {walletService.isKind('Future')
+              ? <DeploymentWithCryptoInfo minimalAmount={walletService.getRequiredDeploymentBalance()}/>
+              : <TopUpCryptoInfo/>
+            }
+            {walletService.isKind('Future') &&
+              <IncomingTransactionsView futureWallet={walletService.getFutureWallet()}/>
+            }
+          </div>
         </div>
       </div>
     </div>

--- a/universal-login-react/src/ui/styles/base/chooseTopUp.sass
+++ b/universal-login-react/src/ui/styles/base/chooseTopUp.sass
@@ -4,7 +4,6 @@
   width: 970px
   max-width: 100%
   padding: 0
-  background: #fff
 
   .unilogin-component-top-up-body-crypto
     min-height: 450px
@@ -222,7 +221,7 @@
     height: 14px
 
   .fiat
-    padding: 25px 0 40px
+    padding: 25px 0 25px
 
   .unilogin-component-amount-input-wrapper
     display: flex

--- a/universal-login-react/src/ui/styles/base/chooseTopUp.sass
+++ b/universal-login-react/src/ui/styles/base/chooseTopUp.sass
@@ -2,7 +2,6 @@
   display: flex
   flex-direction: column
   width: 970px
-  min-height: 615px
   max-width: 100%
   padding: 0
   background: #fff
@@ -26,9 +25,11 @@
     padding: 20px
     flex-grow: 1
     transition: flex-grow 0.2s linear
+    min-height: 615px
 
   &.method-selected .unilogin-component-top-up-header
     flex-grow: initial
+    min-height: 0px
 
   .unilogin-component-top-up-method-title
     margin: 0

--- a/universal-login-react/src/ui/styles/base/chooseTopUp.sass
+++ b/universal-login-react/src/ui/styles/base/chooseTopUp.sass
@@ -6,6 +6,9 @@
   padding: 0
   background: #fff
 
+  .unilogin-component-top-up-body-crypto
+    min-height: 450px
+
   .unilogin-component-modal-title
     margin-bottom: 24px
 

--- a/universal-login-react/src/ui/styles/themes/Jarvis/chooseTopUpThemeJarvis.sass
+++ b/universal-login-react/src/ui/styles/themes/Jarvis/chooseTopUpThemeJarvis.sass
@@ -4,7 +4,6 @@
   display: flex
   flex-direction: column
   max-width: 100%
-  min-height: 590px
 
   .unilogin-component-top-up-header
     display: flex

--- a/universal-login-react/src/ui/styles/themes/Legacy/chooseTopUpThemeLegacy.sass
+++ b/universal-login-react/src/ui/styles/themes/Legacy/chooseTopUpThemeLegacy.sass
@@ -1,6 +1,4 @@
 .unilogin-component-top-up.unilogin-theme-default
-  padding: 20px 0 0
-  background: radial-gradient(720.65px at 50% 0%, #0C0E57 0%, #14052C 100%)
 
   .unilogin-component-top-up-title
     margin: 0 0 27px


### PR DESCRIPTION
In the next steps, I will : 
 - rename `TopUpWithFiat` to `TopUpWithFiatDetails`
 - create `TopUpWithFiat` that will contain `TopUpWithFiatDetails` 
 - move rendering all providers to `TopUpWithFiat`

At the end of this refactoring TopUp will contain only `ChooseTopUpMethod`, `TopUpWithCrypto` and `TopUpWithFiat`.